### PR TITLE
Changing bindings to be domain specific

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,31 @@ The process of integrating this code into a project is as follows:
 * *gather RfEvents*: the client must capture RfEvents, but currently we only care about `DIO0`. You can capture this event with simple polling or by making it interrupt generated. A robust integration should maintain a FIFO queue of events and dispatch them sequentially
 * *dispatch RfEvents*: the client must dispatch the `longfi_handle_event` function with the events gathered above; a robust integration should dispatch this function at a low priority, allowing the system to respond to other higher priority events
 
+## Testing
+
+This library is designed to work on devices that communicate with 8 channel receivers, such as the SX1301/SX1302. We have [a stripped down "hotspot" image available here](https://drive.google.com/file/d/1JfqozFRjeRuGcBKE5RAwseC0yw9oUW9Q/view?usp=sharing), which runs on production hardware as well as on the [RAK "Blackspot"](https://www.adafruit.com/product/4327).
+
+To copy the bootable sdcard.img onto the microSD card:
+
+`$ sudo dd if=output/images/sdcard.img of=/dev/<microSD> bs=1M`
+
+Insert into Raspberry Pi boot. Once you find the device on the network, you can login using SSH.
+
+You need to start the LongFi protocol layer: `/usr/bin/concentrate longfi &`
+
+And then you can tail the messages, including raw radio packets with: `tail -f /var/data/log/messages`
+
+```
+// raw LoRa packet
+Sep 12 17:48:19 gateway user.debug concentrate[176]: received RxPacketLoRa { freq: 916800000, if_chain: 6, crc_check: Pass, timestamp: 929.661612s, radio: R0, bandwidth: BW125kHz, spreading: SF9, coderate: 4/5, rssi: -118.0, snr: 7.5, snr_min: 4.5, snr_max: 9.25, crc: 48637, payload: [0, 2, 0, 0, 0, 40, 40, 254, 239, 247, 146, 22, 133, 85, 181, 183, 12, 126, 112, 0, 11, 0, 0, 9, 74] }
+// parsed LongFi packet
+Sep 12 17:48:19 gateway user.debug concentrate[6713]: [LongFi][app] Packet received: LongFiPkt { oui: 0x2, device_id 0x2828, packet_id: 0x0, mac: 0xeffe, quality: O, crc_fails: 0, payload: [247, 146, 22, 133, 85, 181, 183, 12, 126, 112, 0, 11, 0, 0, 9, 74] }
+// delivered to theorical client
+Sep 12 17:48:19 gateway user.debug concentrate[6713]: [LongFi][app] Sending to client
+```
+
+Alternatively, you can put up a client to the longfi layer: ` /usr/bin/concentrate longfi-test`
+```
+Received packet! Length = 16
+248 18 22 133 85 181 183 12 126 112 0 11 0 0 9 82 
+```

--- a/board.c
+++ b/board.c
@@ -31,13 +31,13 @@ SpiInOut(LF_Spi_t * obj, uint16_t outData)
 void
 GpioWrite(LF_Gpio_t * obj, uint32_t value)
 {
-    (*bindings->gpio_write)(obj, (bool)value);
+    (*bindings->spi_nss)((bool) value);
 }
 
 uint32_t
 GpioRead(LF_Gpio_t * obj)
 {
-    return (*bindings->gpio_read)(obj);
+    return 0;
 }
 
 void

--- a/board.h
+++ b/board.h
@@ -38,6 +38,13 @@ extern "C"
     void     GpioWrite(LF_Gpio_t * obj, uint32_t value);
     uint32_t GpioRead(LF_Gpio_t * obj);
 
+    typedef enum AntPinsMode_t {
+        AntModeTx,
+        AntModeRx,
+        AntModeSleep,
+        _AntModeMax = 0xFFFFFFFF // force 32-bit value
+    } AntPinsMode_t;
+
     typedef void(IrqHandler)(void *);
     typedef void(GpioIrqHandler)(void *);
 
@@ -85,11 +92,15 @@ extern "C"
 
     typedef struct
     {
+        // must provide for drivers to work
         uint8_t (*spi_in_out)(LF_Spi_t * obj, uint8_t outData);
-        void (*gpio_write)(LF_Gpio_t * obj, bool value);
-        bool (*gpio_read)(LF_Gpio_t * obj);
+        void (*spi_nss)(bool sel);
+         void (*reset)(bool enable);
         void (*delay_ms)(uint32_t);
         uint32_t (*get_random_bits)(uint8_t);
+        // optional board control
+        uint8_t (*set_board_tcxo)(bool enable);                           // to control power supply TCXO (wake/sleep)
+        void (*set_antenna_pins)(AntPinsMode_t mode, uint8_t power);      // to control antenna pins for TX/RX/Sleep
     } BoardBindings_t;
 
     extern BoardBindings_t * bindings;

--- a/longfi.c
+++ b/longfi.c
@@ -200,7 +200,6 @@ _send_random(LongFi_t * handle, uint8_t * data, size_t len)
 
 void
 longfi_send(LongFi_t *                               handle,
-            __attribute__((unused)) QualityOfService qos,
             const uint8_t *                          data,
             size_t                                   len)
 {
@@ -285,10 +284,10 @@ longfi_send(LongFi_t *                               handle,
     _send_random(handle, Buffer, internal.tx_cnt);
 }
 
-RxPacket
+RxPacket_t
 longfi_get_rx(__attribute__((unused)) LongFi_t * handle)
 {
-    RxPacket rx = {
+    RxPacket_t rx = {
         .buf  = internal.buffer,
         .len  = internal.rx_len,
         .rssi = RssiValue,
@@ -299,8 +298,8 @@ longfi_get_rx(__attribute__((unused)) LongFi_t * handle)
     return rx;
 }
 
-ClientEvent
-longfi_handle_event(LongFi_t * handle, RfEvent event)
+ClientEvent_t
+longfi_handle_event(LongFi_t * handle, RfEvent_t event)
 {
     internal.cur_event = InternalEvent_None;
 
@@ -340,7 +339,7 @@ longfi_handle_event(LongFi_t * handle, RfEvent event)
     return _handle_internal_event(handle);
 }
 
-ClientEvent
+ClientEvent_t
 _handle_internal_event(LongFi_t * handle)
 {
     switch (internal.cur_event)

--- a/longfi.h
+++ b/longfi.h
@@ -12,14 +12,6 @@ extern "C"
 #include <stdint.h>
 #include <stdlib.h>
 
-    typedef enum QualityOfService
-    {
-        LONGFI_QOS_0,     // send packets with no ACK
-        LONGFI_QOS_1,     // wait for ACK (unimplemented)
-        LONGFI_QOS_2,     // (unimplemented)
-        _MAX = 0xFFFFFFFF // force 32-bit value
-    } QualityOfService;
-
     typedef struct
     {
         uint32_t oui;       // organizations unique identifier
@@ -45,12 +37,12 @@ extern "C"
     void longfi_enable_tcxo(LongFi_t * handle);
 
     // these are the events to be handled by the client
-    typedef enum ClientEvent
+    typedef enum ClientEvent_t
     {
         ClientEvent_None,   // this is a non-event, no handling required
         ClientEvent_TxDone, // the full transmit is complete (1 or more fragments)
         ClientEvent_Rx,     // a full packet was received
-    } ClientEvent;
+    } ClientEvent_t;
 
     // this will give ownership of a buffer to longfi library
     // this should determine max size of transmit/receive BUT currently a static
@@ -61,27 +53,26 @@ extern "C"
     // it is not safe to use this function again without have received
     // ClientEvent_TxDone
     void longfi_send(LongFi_t *       handle,
-                     QualityOfService qos,
                      const uint8_t *  data,
                      size_t           len);
 
     // received packets are returned to the client this way
     // buf is the pointer to the buffer configured in longfi_set_buf
-    typedef struct RxPacket
+    typedef struct RxPacket_t
     {
         uint8_t * buf;
         size_t    len;
         int16_t   rssi;
         int8_t    snr;
-    } RxPacket;
+    } RxPacket_t;
 
     // this returns the received packet
     // (currently there is no user API for receiving packets)
-    RxPacket longfi_get_rx();
+    RxPacket_t longfi_get_rx();
 
     // these are system generated events that the client must collect and push
     // into longfi_handle_event all the DIO events are pin interrupts
-    typedef enum RfEvent
+    typedef enum RfEvent_t
     {
         DIO0,   // TxDone or Rx
         DIO1,   // unimplemented
@@ -92,11 +83,11 @@ extern "C"
         Timer1, // unimplemented
         Timer2, // unimplemented
         Timer3  // unimplemented
-    } RfEvent;
+    } RfEvent_t;
 
     // to be used by client to loop over process_event
     // run at a low priority
-    ClientEvent longfi_handle_event(LongFi_t * handle, RfEvent);
+    ClientEvent_t longfi_handle_event(LongFi_t * handle, RfEvent_t rf_event);
 
     // sends a byte (0xAB) at 910MHz - useful for setting of RF hardware test
     void longfi_rf_test(LongFi_t * handle);

--- a/longfiP.h
+++ b/longfiP.h
@@ -127,7 +127,7 @@ extern "C"
     /*
      * Private helper for handling internal events
      */
-    ClientEvent _handle_internal_event(LongFi_t * handle);
+    ClientEvent_t _handle_internal_event(LongFi_t * handle);
 
     /*
      * Private helper for counting bytes

--- a/radio/sx1276/sx1276.c
+++ b/radio/sx1276/sx1276.c
@@ -41,7 +41,7 @@ typedef struct
     RadioModems_t Modem;
     uint8_t       Addr;
     uint8_t       Value;
-}RadioRegisters_t;
+} RadioRegisters_t;
 
 /*!
  * FSK bandwidth definition
@@ -50,7 +50,7 @@ typedef struct
 {
     uint32_t bandwidth;
     uint8_t  RegValue;
-}FskBandwidth_t;
+} FskBandwidth_t;
 
 
 /*

--- a/radio/sx1276/sx1276.h
+++ b/radio/sx1276/sx1276.h
@@ -429,6 +429,8 @@ uint32_t SX1276GetWakeupTime( void );
 
 Radio_t SX1276RadioNew();
 
+void SX1276EnableTcxo( void );
+
 #ifdef __cplusplus
 }
 #endif

--- a/tests/LongFiSuite.cpp
+++ b/tests/LongFiSuite.cpp
@@ -59,7 +59,7 @@ uint8_t * send_buffer = 0;
 TEST(LongFiGroup, SingleFragmentPacket)
 {
     uint8_t test_data[] = {0xDE, 0xAD, 0xBE, 0xEF};
-    longfi_send(&longfi_handle, LONGFI_QOS_0, test_data, sizeof(test_data));
+    longfi_send(&longfi_handle, test_data, sizeof(test_data));
     
     // assert that the packet sent is equal to test_data plus packet_header
     LONGS_EQUAL(
@@ -92,7 +92,7 @@ TEST(LongFiGroup, TwoFragmentPacket)
         0x07, 0x08, 0x09, 0x0a, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 
         0x19, 0x20};
 
-    longfi_send(&longfi_handle, LONGFI_QOS_0, test_data, sizeof(test_data));
+    longfi_send(&longfi_handle, test_data, sizeof(test_data));
     
     // first packet is 24 bytes
     LONGS_EQUAL(

--- a/tests/RadioSuite.cpp
+++ b/tests/RadioSuite.cpp
@@ -17,18 +17,19 @@ uint8_t spi_in_out(LF_Spi_t *obj, uint8_t outData){
   return 0x3E;
 };
 
-void gpio_write(LF_Gpio_t *obj, bool value){
-}
 
-bool gpio_read(LF_Gpio_t *obj){
-  return false;
-}
+void spi_nss(bool not_select){
+};
+
 
 void delay_ms(uint32_t){
 }
 
 uint32_t get_random_bits(uint8_t){
   return 0xE0;
+}
+
+void radio_reset(bool){
 }
 
 static Radio_t sx1276;
@@ -38,12 +39,13 @@ static Radio_t sx126x;
 static LongFi_t longfi_handle;
 BoardBindings_t my_bindings {
   .spi_in_out = spi_in_out,
-  .gpio_write = gpio_write,
-  .gpio_read = gpio_read,
+  .spi_nss = spi_nss,
+  .reset = radio_reset,
   .delay_ms = delay_ms,
   .get_random_bits = get_random_bits,
+  .set_board_tcxo = NULL,
+  .set_antenna_pins = NULL,
 };
-
 
 TEST_GROUP(RadioGroup)
 {


### PR DESCRIPTION
The principle of this change results in the following:
```
    typedef enum ANT_PINS_MODE {
        ANT_MODE_TX,
        ANT_MODE_RX,
        ANT_MODE_SLEEP
    } ANT_PINS_MODE;

extern BoardBindings_t * bindings;

    typedef struct Radio_s Radio_t;

    typedef struct
    {
        // must provide for drivers to work
        uint8_t (*spi_in_out)(LF_Spi_t * obj, uint8_t outData);
        void (*spi_cs)(bool sel);
        void (*delay_ms)(uint32_t);
        uint32_t (*get_random_bits)(uint8_t);

        // optional board control
        void (*set_board_tcxo)(bool enable);                           // to control power supply TCXO (wake/sleep)
        void (*set_antenna_pins)(ANT_PINS_MODE mode, uint8_t power);   // to control antenna pins for TX/RX/Sleep
    } BoardBindings_t;

    extern BoardBindings_t * bindings;
``` 
As a replacement for:

```
// Above is everything that SX127x's depend on
// Rather then requiring statically linked functions
// We will change to runtime loaded
#include "radio/radio.h"
typedef struct Radio_s Radio_t;

typedef struct {
	uint16_t (*spi_in_out)(LF_Spi_t *obj, uint16_t outData);
	void (*gpio_init)(LF_Gpio_t *obj, PinNames pin, PinModes mode, PinConfigs config, PinTypes type, uint32_t value);
	void (*gpio_write)(LF_Gpio_t *obj, uint32_t value);
    uint32_t (*gpio_read)(LF_Gpio_t *obj);
	void (*gpio_set_interrupt)( LF_Gpio_t *obj, IrqModes irqMode, IrqPriorities irqPriority, GpioIrqHandler *irqHandler);
	void (*delay_ms)(uint32_t);
} BoardBindings_t;
```

The goal is to do away with giving a GPIO API to the library, but instead radio-specific bindings. This should make the integration job more explicit and flexible. Implementation examples coming soon, as I will test this PR with `longfi-device-rs` before merging with master.