### PR TITLE
force 32-bit value for AuthMode enum

### DIFF
--- a/longfi.h
+++ b/longfi.h
@@ -20,6 +20,7 @@ extern "C"
     typedef enum
     {
         PresharedKey128,
+	_LongFiAuthModeMax = 0xFFFFFFFF // fore 32-bit value
         // TODO: ECDH
     } LongFiAuthMode_t;
 


### PR DESCRIPTION
This fixes the bug where Fingerprinting was not working from `longfi-device-rs`. This was an issue I've experienced previously where C and Rust will generate enums of different sizes (I believe 8-bit and 32 -bit respectively) unless you force the 32-bit value by declaring an enum with a 32-bit value explicitly assigned.