### PR TITLE
lthiery/sx126x fix

### DIFF
--- a/longfi.c
+++ b/longfi.c
@@ -292,6 +292,7 @@ _handle_internal_event(LongFi_t * handle)
         // if all the tx data is sent, we're done!
         if (internal.tx_len == internal.tx_cnt)
         {
+            handle->radio->Sleep();
             return ClientEvent_TxDone;
         }
         // else we are sending another fragment

--- a/radio/sx126x/radio.c
+++ b/radio/sx126x/radio.c
@@ -507,6 +507,8 @@ void SX126xRadioInit( RadioEvents_t *events )
     SX126xSetTxParams( 0, RADIO_RAMP_200_US );
     SX126xSetDioIrqParams( IRQ_RADIO_ALL, IRQ_RADIO_ALL, IRQ_RADIO_NONE, IRQ_RADIO_NONE );
 
+    SX126xIoTcxoInit();
+
     // Initialize driver timeout timers
     TimerInit( &SX126xTxTimeoutTimer, SX126xRadioOnTxTimeoutIrq );
     TimerInit( &SX126xRxTimeoutTimer, SX126xRadioOnRxTimeoutIrq );

--- a/radio/sx126x/sx126x-board.c
+++ b/radio/sx126x/sx126x-board.c
@@ -70,13 +70,11 @@ void SX126xIoTcxoInit( void )
     SX126xSetDio3AsTcxoCtrl( TCXO_CTRL_1_7V, SX126xGetBoardTcxoWakeupTime( ) << 6 ); // convert from ms to SX126x time base
     calibParam.Value = 0x7F;
     SX126xCalibrate( calibParam );
-
-    SX126xSetDio2AsRfSwitchCtrl(true);
 }
 
 uint32_t SX126xGetBoardTcxoWakeupTime( void )
 {
-    return 6;
+    return 8;
 }
 
 void SX126xReset( void )
@@ -102,8 +100,6 @@ void SX126xWakeup( void )
 
     GpioWrite( &SX126x.Spi.Nss, 1 );
 
-    // Wait for chip to be ready.
-    SX126xWaitOnBusy( );
 }
 
 void SX126xWriteCommand( RadioCommands_t command, uint8_t *buffer, uint16_t size )
@@ -253,11 +249,11 @@ void SX126xAntSwOn( void )
     if( bindings->set_antenna_pins!= NULL ){
         (*bindings->set_antenna_pins)(AntModeTx, 0);
     }
+    RadioIsActive = true;
 }
 
 void SX126xAntSwOff( void )
 {
-
     if( bindings->set_antenna_pins!= NULL ){
         (*bindings->set_antenna_pins)(AntModeSleep, 0);
     }


### PR DESCRIPTION
This is unfortunately a bit of a hack at the moment. In order to get the radio to transmit, I needed to call `SX126xIoTcxoInit();` from `SX126xRadioSend` which I believe is then forcing me to wait 200 ms after the `SX126xSetPacketParams` command. If I do not wait 200 ms, the change in payload length does not appear to register and a payload of "max payload size" is transmitted.