### PR TITLE
Workaround for SX126x

### DIFF
--- a/longfi.c
+++ b/longfi.c
@@ -292,6 +292,7 @@ _handle_internal_event(LongFi_t * handle)
         // if all the tx data is sent, we're done!
         if (internal.tx_len == internal.tx_cnt)
         {
+            handle->radio->Sleep();
             return ClientEvent_TxDone;
         }
         // else we are sending another fragment

--- a/longfi.c
+++ b/longfi.c
@@ -35,12 +35,6 @@ longfi_new_handle(BoardBindings_t *         bindings,
 }
 
 void
-longfi_enable_tcxo(LongFi_t * handle)
-{
-    handle->radio->EnableTcxo();
-}
-
-void
 longfi_init(LongFi_t * handle)
 {
     // store pointer to internal context for callback definitions
@@ -76,36 +70,8 @@ longfi_init(LongFi_t * handle)
     // implemented here
     handle->radio->Init(&internal.radio_events);
 
-    handle->radio->SetChannel(uplink_channel_map[0]);
-
-    handle->radio->SetTxConfig(MODEM_LORA,
-                               TX_OUTPUT_POWER,
-                               0,
-                               LORA_BANDWIDTH,
-                               LORA_SPREADING_FACTOR,
-                               LORA_CODINGRATE,
-                               LORA_PREAMBLE_LENGTH,
-                               LORA_FIX_LENGTH_PAYLOAD_ON,
-                               true,
-                               0,
-                               0,
-                               LORA_IQ_INVERSION_ON,
-                               3000);
-
-    handle->radio->SetRxConfig(MODEM_LORA,
-                               LORA_BANDWIDTH,
-                               LORA_SPREADING_FACTOR,
-                               LORA_CODINGRATE,
-                               0,
-                               LORA_PREAMBLE_LENGTH,
-                               LORA_SYMBOL_TIMEOUT,
-                               LORA_FIX_LENGTH_PAYLOAD_ON,
-                               0,
-                               true,
-                               0,
-                               0,
-                               LORA_IQ_INVERSION_ON,
-                               true);
+    // sleep the radio and wait for a send or receive call
+    handle->radio->Sleep();
 }
 
 void
@@ -246,11 +212,8 @@ longfi_handle_event(LongFi_t * handle, RfEvent_t event)
         (*(internal.dio_irq_handles[0]))();
         break;
     case DIO1:
-        // if (internal.dio_irq_handles[1]!= NULL){
-        //     (*internal.dio_irq_handles[1])();
-        // } else {
+        // SX126x library only has the one handle, so fire it even fore DIO1
         (*(internal.dio_irq_handles[0]))();
-        //}
         break;
     case DIO2:
         (*internal.dio_irq_handles[2])();
@@ -292,6 +255,7 @@ _handle_internal_event(LongFi_t * handle)
         // if all the tx data is sent, we're done!
         if (internal.tx_len == internal.tx_cnt)
         {
+            // sleep when done transmitting
             handle->radio->Sleep();
             return ClientEvent_TxDone;
         }

--- a/radio/sx126x/radio.c
+++ b/radio/sx126x/radio.c
@@ -907,7 +907,7 @@ uint32_t SX126xRadioTimeOnAir( RadioModems_t modem, uint8_t pktLen )
 void SX126xRadioSend( uint8_t *buffer, uint8_t size )
 {
     // Initialize TCXO control (workaround since)
-    SX126xIoTcxoInit();
+    //SX126xIoTcxoInit();
 
     SX126xSetDioIrqParams( IRQ_TX_DONE | IRQ_RX_TX_TIMEOUT,
                            IRQ_TX_DONE | IRQ_RX_TX_TIMEOUT,

--- a/radio/sx126x/radio.c
+++ b/radio/sx126x/radio.c
@@ -906,6 +906,9 @@ uint32_t SX126xRadioTimeOnAir( RadioModems_t modem, uint8_t pktLen )
 
 void SX126xRadioSend( uint8_t *buffer, uint8_t size )
 {
+    // Initialize TCXO control (workaround since)
+    SX126xIoTcxoInit();
+
     SX126xSetDioIrqParams( IRQ_TX_DONE | IRQ_RX_TX_TIMEOUT,
                            IRQ_TX_DONE | IRQ_RX_TX_TIMEOUT,
                            IRQ_RADIO_NONE,

--- a/radio/sx126x/radio.c
+++ b/radio/sx126x/radio.c
@@ -907,7 +907,7 @@ uint32_t SX126xRadioTimeOnAir( RadioModems_t modem, uint8_t pktLen )
 void SX126xRadioSend( uint8_t *buffer, uint8_t size )
 {
     // Initialize TCXO control (workaround since)
-    //SX126xIoTcxoInit();
+    SX126xIoTcxoInit();
 
     SX126xSetDioIrqParams( IRQ_TX_DONE | IRQ_RX_TX_TIMEOUT,
                            IRQ_TX_DONE | IRQ_RX_TX_TIMEOUT,

--- a/radio/sx126x/sx126x-board.c
+++ b/radio/sx126x/sx126x-board.c
@@ -70,8 +70,6 @@ void SX126xIoTcxoInit( void )
     SX126xSetDio3AsTcxoCtrl( TCXO_CTRL_1_7V, SX126xGetBoardTcxoWakeupTime( ) << 6 ); // convert from ms to SX126x time base
     calibParam.Value = 0x7F;
     SX126xCalibrate( calibParam );
-
-    SX126xSetDio2AsRfSwitchCtrl(true);
 }
 
 uint32_t SX126xGetBoardTcxoWakeupTime( void )

--- a/radio/sx126x/sx126x.c
+++ b/radio/sx126x/sx126x.c
@@ -633,6 +633,8 @@ void SX126xSetPacketParams( PacketParams_t *packetParams )
         return;
     }
     SX126xWriteCommand( SX126x_RADIO_SET_PACKETPARAMS, buf, n );
+    Delay(200);
+    SX126xWaitOnBusy( );
 }
 
 void SX126xSetCadParams( RadioLoRaCadSymbols_t cadSymbolNum, uint8_t cadDetPeak, uint8_t cadDetMin, RadioCadExitModes_t cadExitMode, uint32_t cadTimeout )


### PR DESCRIPTION
On every send, SX126xIoTcxoInit() is called. In addition, a 200 ms delay to `SX126xSetPacketParams`, otherwise the send takes multiple seconds. This PR is more or less a workaround for undesirable default behavior. There is either user error on my behalf or something is up with the SX126x library.