### PR TITLE
A small set of edits that allow Heltec ESP32 target support

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,18 @@ Currently, only uplink is supported.
    ```
    cmake -H. -Bbuild  -DCMAKE_TOOLCHAIN_FILE=../toolchain-gcc-arm-none-eabi.cmake -DCMAKE_FLAGS="-march=armv6s-m"
    ```
+   or to cross compile for Heltec ESP32
+   ```
+   PATH="$PATH:~/.arduino15/packages/Heltec-esp32/tools/xtensa-esp32-elf-gcc/1.22.0-80-g6c4433a-5.2.0/bin/" cmake -H. -Bbuild  -DCMAKE_TOOLCHAIN_FILE=toolchain-gcc-xtensa-esp32.cmake
+   ```
 1. Compile
    ```
    make -C build
+   ```
+1. Copy built static libraries to Arduino LongFi
+   use esp32/cortex-m0/etc depending on what board you've built for
+   ```
+   find ./ -iname "*.a" -exec cp {} /home/lokkju/Arduino/libraries/LongFi/src/esp32/ \;
    ```
 1. Documentation
    ```

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Currently, only uplink is supported.
 1. Copy built static libraries to Arduino LongFi
    use esp32/cortex-m0/etc depending on what board you've built for
    ```
-   find ./ -iname "*.a" -exec cp {} /home/lokkju/Arduino/libraries/LongFi/src/esp32/ \;
+   find ./ -iname "*.a" -exec cp {} ~/Arduino/libraries/LongFi/src/esp32/ \;
    ```
 1. Documentation
    ```

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Currently, only uplink is supported.
    ```
    cmake -H. -Bbuild  -DCMAKE_TOOLCHAIN_FILE=../toolchain-gcc-arm-none-eabi.cmake -DCMAKE_FLAGS="-march=armv6s-m"
    ```
-   or to cross compile for Heltec ESP32
+   or to cross compile for Heltec ESP32 (after [setting up the Heltec ESP32 toolchain](https://docs.espressif.com/projects/esp-idf/en/release-v3.0/get-started/linux-setup.html))
    ```
    PATH="$PATH:~/.arduino15/packages/Heltec-esp32/tools/xtensa-esp32-elf-gcc/1.22.0-80-g6c4433a-5.2.0/bin/" cmake -H. -Bbuild  -DCMAKE_TOOLCHAIN_FILE=toolchain-gcc-xtensa-esp32.cmake
    ```

--- a/README.md
+++ b/README.md
@@ -28,11 +28,6 @@ Currently, only uplink is supported.
    ```
    make -C build
    ```
-1. Copy built static libraries to Arduino LongFi
-   use esp32/cortex-m0/etc depending on what board you've built for
-   ```
-   find ./ -iname "*.a" -exec cp {} ~/Arduino/libraries/LongFi/src/esp32/ \;
-   ```
 1. Documentation
    ```
    make -C build docs

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ The process of integrating this code into a project is as follows:
 
  } BoardBindings_t;
 ```
-* *gather RfEvents*: the client must capture RfEvents, but currently we only care about `DIO0` for SX127x and `DIO1` for SX126x. You can capture this event with simple polling or by making it interrupt generated. A robust integration should maintain a FIFO queue of events and dispatch them sequentially
+* *gather RfEvents*: the client must capture RfEvents, but currently we only care about `RFE_DIO0` for SX127x and `RFE_DIO1` for SX126x. You can capture this event with simple polling or by making it interrupt generated. A robust integration should maintain a FIFO queue of events and dispatch them sequentially
 * *dispatch RfEvents*: the client must dispatch the `longfi_handle_event` function with the events gathered above; a robust integration should dispatch this function at a low priority, allowing the system to respond to other higher priority events
 * *send message*: the client can send messages, but must take care to only dispatch a single send at time; `ClientEvent_TxDone` signals that the library is ready to send again
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Currently, only uplink is supported.
    ```
    or to cross compile for Heltec ESP32 (after [setting up the Heltec ESP32 toolchain](https://docs.espressif.com/projects/esp-idf/en/release-v3.0/get-started/linux-setup.html))
    ```
-   PATH="$PATH:~/.arduino15/packages/Heltec-esp32/tools/xtensa-esp32-elf-gcc/1.22.0-80-g6c4433a-5.2.0/bin/" cmake -H. -Bbuild  -DCMAKE_TOOLCHAIN_FILE=toolchain-gcc-xtensa-esp32.cmake
+ cmake -H. -Bbuild  -DCMAKE_TOOLCHAIN_FILE=toolchain-gcc-xtensa-esp32.cmake
    ```
 1. Compile
    ```

--- a/longfi.c
+++ b/longfi.c
@@ -208,32 +208,32 @@ longfi_handle_event(LongFi_t * handle, RfEvent_t event)
 
     switch (event)
     {
-    case DIO0:
+    case RFE_DIO0:
         (*(internal.dio_irq_handles[0]))();
         break;
-    case DIO1:
+    case RFE_DIO1:
         // SX126x library only has the one handle, so fire it even fore DIO1
         (*(internal.dio_irq_handles[0]))();
         break;
-    case DIO2:
+    case RFE_DIO2:
         (*internal.dio_irq_handles[2])();
         break;
-    case DIO3:
+    case RFE_DIO3:
         (*internal.dio_irq_handles[3])();
         break;
-    case DIO4:
+    case RFE_DIO4:
         (*internal.dio_irq_handles[4])();
         break;
-    case DIO5:
+    case RFE_DIO5:
         (*internal.dio_irq_handles[5])();
         break;
-    case Timer1:
+    case RFE_Timer1:
         // TODO: needs to dispatch the callback stashed from TimerInit
         break;
-    case Timer2:
+    case RFE_Timer2:
         // TODO: needs to dispatch the callback stashed from TimerInit
         break;
-    case Timer3:
+    case RFE_Timer3:
         // TODO: needs to dispatch the callback stashed from TimerInit
         break;
     default:

--- a/longfi.h
+++ b/longfi.h
@@ -129,15 +129,15 @@ extern "C"
      */
     typedef enum RfEvent_t
     {
-        DIO0,   // TxDone or Rx
-        DIO1,   // unimplemented
-        DIO2,   // unimplemented
-        DIO3,   // unimplemented
-        DIO4,   // unimplemented
-        DIO5,   // unimplemented
-        Timer1, // unimplemented
-        Timer2, // unimplemented
-        Timer3  // unimplemented
+        RFE_DIO0,   // TxDone or Rx
+        RFE_DIO1,   // unimplemented
+        RFE_DIO2,   // unimplemented
+        RFE_DIO3,   // unimplemented
+        RFE_DIO4,   // unimplemented
+        RFE_DIO5,   // unimplemented
+        RFE_Timer1, // unimplemented
+        RFE_Timer2, // unimplemented
+        RFE_Timer3  // unimplemented
     } RfEvent_t;
 
     /*!

--- a/toolchain-gcc-xtensa-esp32.cmake
+++ b/toolchain-gcc-xtensa-esp32.cmake
@@ -1,0 +1,28 @@
+set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
+
+###########################################################################
+# Toolchain executables                                                   #
+###########################################################################
+find_program(TOOLCHAIN_CC      "xtensa-esp32-elf-gcc")
+find_program(TOOLCHAIN_CXX     "xtensa-esp32-elf-g++")
+find_program(TOOLCHAIN_OBJCOPY "xtensa-esp32-elf-objcopy")
+find_program(TOOLCHAIN_OBJDUMP "xtensa-esp32-elf-objdump")
+find_program(TOOLCHAIN_SIZE    "xtensa-esp32-elf-size")
+find_program(TOOLCHAIN_LD      "xtensa-esp32-elf-ld")
+
+set(CMAKE_C_COMPILER   ${TOOLCHAIN_CC})
+set(CMAKE_CXX_COMPILER ${TOOLCHAIN_CXX})
+set(CMAKE_SYSTEM_NAME Generic)
+
+# All
+set(CMAKE_C_FLAGS "-ffunction-sections -fdata-sections -mlongcalls")
+set(CMAKE_CXX_FLAGS "-ffunction-sections -fdata-sections -mlongcalls")
+
+# Debug
+set(CMAKE_C_FLAGS_DEBUG "-ggdb3 -Og")
+set(CMAKE_CXX_FLAGS_DEBUG "-ggdb3 -Og")
+
+# Release
+set(CMAKE_C_FLAGS_RELEASE "-DNDEBUG -Os -flto")
+set(CMAKE_CXX_FLAGS_RELEASE "-DNDEBUG -Os -flto")
+set(CMAKE_EXE_LINKER_FLAGS_RELEASE "-Os -flto -Wno-lto-type-mismatch")


### PR DESCRIPTION
Primarily includes edits to make the RfEvent enum names unique (DIO0 is a widely used name) and a cmake toolchain file for compiling for Heltec ESP32 targets (using the Arduino board support package)